### PR TITLE
fixing typo, minor workflow tweaks

### DIFF
--- a/.github/workflows/build-push-image-commit.yaml
+++ b/.github/workflows/build-push-image-commit.yaml
@@ -14,11 +14,6 @@ jobs:
       image-tag: ${{ steps.build-and-push.outputs.IMAGE_SHA_TAG }}
 
     steps:
-      - name: Cleanup disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
-          df -h
-
       - name: Check out the image repo
         uses: actions/checkout@v4
         with:
@@ -34,6 +29,12 @@ jobs:
             LICENSE
             .github/**
             images/**
+
+      - name: Cleanup disk space
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          df -h
 
       - name: Log in to GAR
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -81,7 +82,6 @@ jobs:
           repository: 'berkeley-dsep-infra/datahub'
           sparse-checkout: |
             deployments/
-            hub/
   
       - name: Set git identity
         if: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -9,11 +9,6 @@ jobs:
     env:
       DOCKER_CONFIG: $HOME/.docker
     steps:
-      - name: cleanup disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
-          df -h
-
       - name: Checkout files in repo
         uses: actions/checkout@v4
 
@@ -28,13 +23,11 @@ jobs:
             .github/**
             images/**
 
-      - name: What files changed?
+      - name: Cleanup disk space
         if: steps.changed-files.outputs.any_changed == 'true'
-        env:
-            CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-            echo "One or more image file(s) has changed:"
-            echo "$CHANGED_FILES"
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          df -h
 
       - name: Build and test the image if any image file(s) changed
         if: steps.changed-files.outputs.any_changed == 'true'


### PR DESCRIPTION

in CONTRIBUTING.md, s/repo2-docker/repo2docker/g

in the build workflows, we should only cleanup disk space if we're going to build the image... this usually takes ~15sec to run, so it'll save us a bit of time when changes to the docs are pushed and the image isn't built.